### PR TITLE
Clean panic if invalid number of arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use std::env;
 use std::path::Path;
 
 fn main() {
+    if env::args().count() != 2 {
+        panic!("Invalid number of arguments given");
+    }
     let root_arg = env::args().nth(1).unwrap();
     let root = Path::new(&root_arg);
 


### PR DESCRIPTION
Fixes #3. This is a temporary patch to give a more verbose error message until something like #4 is implemented.